### PR TITLE
Edgari/dev passthrough

### DIFF
--- a/xen/drivers/passthrough/device_tree.c
+++ b/xen/drivers/passthrough/device_tree.c
@@ -115,10 +115,11 @@ int iommu_release_dt_devices(struct domain *d)
     list_for_each_entry_safe(dev, _dev, &hd->dt_devices, domain_list)
     {
         rc = iommu_deassign_dt_device(d, dev);
-        if ( rc )
+        if ( rc ) {
             dprintk(XENLOG_ERR, "Failed to deassign %s in domain %u\n",
                     dt_node_full_name(dev), d->domain_id);
-        return rc;
+            return rc;
+        }
     }
 
     return 0;


### PR DESCRIPTION
Added functionality so that multiple devices that use the same SMMU and are passed through to the same xen domain use the same context bank instead of a new one. 

Also, fixed a couple bugs with deassigning multiple devices from a single xen domain. 
